### PR TITLE
Populate return URL when using Google Signin

### DIFF
--- a/spongeauth/accounts/tests/test_view_login.py
+++ b/spongeauth/accounts/tests/test_view_login.py
@@ -30,6 +30,11 @@ class TestLogin(django.test.TestCase):
         resp = self.client.get(self.path() + '?next=https://www.google.com/')
         assert 'google.com' not in resp['Location']
 
+    def test_next_appears_in_template(self):
+        resp = self.client.get(self.path() + '?next=/aardvark/')
+        assert 'next' in resp.context
+        assert resp.context['next'] == '/aardvark/'
+
     @unittest.mock.patch('accounts.views.login_google')
     def test_invokes_login_google_if_google(self, mock_login_google):
         mock_login_google.return_value = django.http.HttpResponse('ohai')

--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -205,7 +205,9 @@ def register(request):
                 _send_verify_email(request, user)
             return resp
 
-    return render(request, 'accounts/register.html', {'form': form})
+    return render(request, 'accounts/register.html', {
+        'form': form,
+        'next': _login_redirect_url(request)})
 
 
 @require_POST

--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -176,7 +176,9 @@ def login(request):
         if form.is_valid() and hasattr(form, 'cached_user'):
             return _log_user_in(request, form.cached_user)
 
-    return render(request, 'accounts/login.html', {'form': form})
+    return render(request, 'accounts/login.html', {
+        'form': form,
+        'next': _login_redirect_url(request)})
 
 
 def register(request):

--- a/spongeauth/templates/accounts/_google_signin_form.html
+++ b/spongeauth/templates/accounts/_google_signin_form.html
@@ -1,5 +1,8 @@
 <form style="display: none;" id="form-glogin" method="POST" action="{% url 'accounts:login' %}">
     {% csrf_token %}
+    {% if next %}
+        <input type="hidden" name="next" value="{{ next }}">
+    {% endif %}
     <input type="hidden" name="google_id_token">
     <input type="hidden" name="login_type" value="google">
 </form>

--- a/spongeauth/templates/accounts/login.html
+++ b/spongeauth/templates/accounts/login.html
@@ -9,11 +9,11 @@
 		<div class="col-md-6 col-md-offset-3">
 			<div class="panel panel-default panel-signup">
 				<div class="panel-heading">
-                    <h4 class="panel-title">{% trans "Log in" %}</h4>
+          <h4 class="panel-title">{% trans "Log in" %}</h4>
 				</div>
 
 				<div class="panel-body">
-                    {% crispy form %}
+          {% crispy form %}
 				</div><!-- .panel-body -->
 			</div><!-- .panel -->
 		</div><!-- .col-md-6 -->


### PR DESCRIPTION
This should mean that logging in from the forums is now less tedious if you're using Google Signin.

Fixes #82 