### PR TITLE
Log people out of all the things

### DIFF
--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -157,7 +157,10 @@ def logout(request):
 def logout_success(request):
     if request.user.is_authenticated():
         return redirect('index')
-    return render(request, 'accounts/logout_success.html')
+
+    resp = render(request, 'accounts/logout_success.html')
+    resp['Clear-Site-Data'] = '"cache", "cookies", "storage", "executionContexts"'
+    return resp
 
 
 def login(request):

--- a/spongeauth/templates/accounts/logout_success.html
+++ b/spongeauth/templates/accounts/logout_success.html
@@ -20,4 +20,20 @@
 		</div><!-- .col-md-6 -->
 	</div><!-- .row -->
 </div><!-- .container -->
+
+<!-- sneaky continue logout -->
+<script>
+(function() {
+    const origins = ["https://ore.spongepowered.org", "https://forums.spongepowered.org"];
+    origins.forEach(function(origin) {
+        console.log("Logging out of " + origin);
+        fetch(origin + "/_logout", {
+            method: 'DELETE',
+            mode: 'cors',
+            credentials: true,
+            cache: 'no-cache'
+        });
+    });
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
Make some CORS requests to some endpoints which will set headers to clear cookies iff the request comes from https://auth.spongepowered.org

This will also log people out of things if they hit the success endpoint when they're not logged in to auth, so maybe a good thing.