### PR TITLE
Some user/group admin fixes

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,8 +3,9 @@ django-user-sessions==1.6.0
 Pillow==5.2.0
 oauth2client==4.1.2
 django-crispy-forms==1.7.2
--e git://github.com/jazzband/django-model-utils.git@3.1.1#egg=django-model-utils
+django-model-utils==3.1.2
 qrcode==6.0
 pytz==2018.5
 requests==2.19.1
 psycopg2-binary==2.7.5
+django-autocomplete-light==3.3.0

--- a/spongeauth/accounts/admin.py
+++ b/spongeauth/accounts/admin.py
@@ -8,6 +8,8 @@ from django.utils import timezone
 
 from . import models
 
+from dal import autocomplete
+
 
 class AdminUserChangeForm(forms.ModelForm):
     password = django.contrib.auth.forms.ReadOnlyPasswordHashField(
@@ -102,8 +104,13 @@ class GroupAdminForm(forms.ModelForm):
 
     users = forms.ModelMultipleChoiceField(
         queryset=models.User.objects.all(),
+        widget=autocomplete.ModelSelect2Multiple(
+            url='accounts:users-autocomplete',
+            attrs={
+                'data-minimum-input-length': 3,
+            },
+        ),
         required=False,
-        widget=widgets.FilteredSelectMultiple('users', False),
     )
 
     def __init__(self, *args, **kwargs):

--- a/spongeauth/accounts/admin.py
+++ b/spongeauth/accounts/admin.py
@@ -29,6 +29,19 @@ class AdminUserChangeForm(forms.ModelForm):
         if self.instance.pk:
             self.fields['groups'].initial = self.instance.groups.all()
 
+    def _get_validation_exclusions(self):
+        exclude = super()._get_validation_exclusions()
+        if self.instance:
+            # Don't validate the username if it isn't changing.
+            # We have some legacy usernames that now fail validation.
+            exclude_if_same = ('username',)
+            for field in exclude_if_same:
+                new_value = self.cleaned_data.get(field)
+                old_value = getattr(self.instance, field)
+                if new_value == old_value:
+                    exclude += [field]
+        return exclude
+
     def save_m2m(self):
         self.instance.groups.set(self.cleaned_data['groups'])
 

--- a/spongeauth/accounts/tests/test_admin.py
+++ b/spongeauth/accounts/tests/test_admin.py
@@ -1,4 +1,5 @@
 import unittest.mock
+import pytest
 
 from .. import admin
 from .. import models
@@ -44,3 +45,39 @@ class TestUserAdmin:
         obj.delete_model(None, user)
         assert user.deleted_at is not None
         assert not user.is_active
+
+
+@pytest.mark.django_db
+class TestAdminUserChangeForm:
+
+    def make_post_data(self, user, **kwargs):
+        post_data = {
+            'username': user.username,
+            'email': user.email,
+        }
+        bool_fields = ['email_verified', 'is_active']
+        for bool_field in bool_fields:
+            if getattr(user, bool_field):
+                post_data[bool_field] = 'on'
+        post_data.update(**kwargs)
+        return post_data
+
+    def test_does_not_validate_username_if_it_is_unchanged(self):
+        user = factories.UserFactory.create(username='ewoutvs_')
+        post_data = self.make_post_data(user)
+        form = admin.AdminUserChangeForm(post_data, instance=user)
+        form.save()
+
+    def test_does_validate_username_if_it_changes(self):
+        user = factories.UserFactory.create(username='ewoutvs_')
+        post_data = self.make_post_data(user, username='ewoutvs__')
+        form = admin.AdminUserChangeForm(post_data, instance=user)
+        with pytest.raises(ValueError):
+            form.save()
+
+    def test_validates_username(self):
+        user = factories.UserFactory.create()
+        post_data = self.make_post_data(user, username='ewoutvs_')
+        form = admin.AdminUserChangeForm(post_data, instance=user)
+        with pytest.raises(ValueError):
+            form.save()

--- a/spongeauth/accounts/tests/test_view_autocomplete.py
+++ b/spongeauth/accounts/tests/test_view_autocomplete.py
@@ -1,0 +1,58 @@
+import django.test
+import django.shortcuts
+
+from . import factories
+from . import test_models
+from .. import models
+
+import json
+
+
+class TestViewAutocomplete(django.test.TestCase):
+    def setUp(self):
+        self.user = factories.UserFactory.create(
+            is_staff=True, is_admin=True)
+        self.client = django.test.Client()
+        assert self.client.login(username=self.user.username, password='secret')
+
+    def path(self):
+        return django.shortcuts.reverse('accounts:users-autocomplete')
+
+    def test_get_no_permission(self):
+        self.user.is_staff = False
+        self.user.is_admin = False
+        self.user.save()
+        resp = self.client.get(self.path())
+        assert resp.status_code == 200
+        resp_dict = json.loads(resp.content)
+        assert resp_dict['results'] == []
+
+    def test_get_without_query(self):
+        resp = self.client.get(self.path())
+        assert resp.status_code == 200
+        resp_dict = json.loads(resp.content)
+        assert resp_dict['results'] == [
+            {
+                "id": str(self.user.id),
+                "text": self.user.username,
+                "selected_text": self.user.username,
+            }
+        ]
+
+    def test_get_with_query_match(self):
+        resp = self.client.get(self.path() + '?q=' + self.user.username[:2])
+        assert resp.status_code == 200
+        resp_dict = json.loads(resp.content)
+        assert resp_dict['results'] == [
+            {
+                "id": str(self.user.id),
+                "text": self.user.username,
+                "selected_text": self.user.username,
+            }
+        ]
+
+    def test_get_with_query_no_match(self):
+        resp = self.client.get(self.path() + '?q=!')
+        assert resp.status_code == 200
+        resp_dict = json.loads(resp.content)
+        assert resp_dict['results'] == []

--- a/spongeauth/accounts/tests/test_view_autocomplete.py
+++ b/spongeauth/accounts/tests/test_view_autocomplete.py
@@ -2,8 +2,6 @@ import django.test
 import django.shortcuts
 
 from . import factories
-from . import test_models
-from .. import models
 
 import json
 

--- a/spongeauth/accounts/urls.py
+++ b/spongeauth/accounts/urls.py
@@ -34,4 +34,7 @@ urlpatterns = [
         name='forgot-step2'),
 
     url(r'^agree-tos/$', accounts.views.agree_tos, name='agree-tos'),
+
+    url(r'^__internal/autocomplete/users/$', accounts.views.UserAutocomplete.as_view(),
+        name='users-autocomplete'),
 ]

--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -605,11 +605,10 @@ def agree_tos(request):
 
 class UserAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
-        if not self.request.user.is_authenticated:
-            return models.User.none()
-        if not self.request.user.has_perm('accounts.view_user'):
-            return models.User.none()
         users = models.User.objects.all()
+        if (not self.request.user.is_authenticated or
+            not self.request.user.has_perm('accounts.view_user')):
+            users = models.User.objects.none()
         if self.q:
             users = users.filter(username__istartswith=self.q)
-        return users
+        return users.order_by('username')

--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -606,8 +606,9 @@ def agree_tos(request):
 class UserAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         users = models.User.objects.all()
-        if (not self.request.user.is_authenticated or
-            not self.request.user.has_perm('accounts.view_user')):
+        if (
+                not self.request.user.is_authenticated or
+                not self.request.user.has_perm('accounts.view_user')):
             users = models.User.objects.none()
         if self.q:
             users = users.filter(username__istartswith=self.q)

--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -24,6 +24,7 @@ from . import forms
 from . import middleware
 
 from oauth2client import client, crypt
+from dal import autocomplete
 
 
 class VerifyTokenGenerator(django.contrib.auth.tokens.PasswordResetTokenGenerator):
@@ -600,3 +601,15 @@ def agree_tos(request):
         'user': user,
         'toses': unagreed_tos,
         'has_previously_agreed_tos': has_previously_agreed_tos})
+
+
+class UserAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if not self.request.user.is_authenticated:
+            return models.User.none()
+        if not self.request.user.has_perm('accounts.view_user'):
+            return models.User.none()
+        users = models.User.objects.all()
+        if self.q:
+            users = users.filter(username__istartswith=self.q)
+        return users

--- a/spongeauth/spongeauth/settings/base.py
+++ b/spongeauth/spongeauth/settings/base.py
@@ -43,6 +43,8 @@ INSTALLED_APPS = [
     'api',
 
     'crispy_forms',
+    'dal',
+    'dal_select2',
 
     'django.contrib.admin',
     'django.contrib.auth',

--- a/spongeauth/sso/tests/test_send_update_ping.py
+++ b/spongeauth/sso/tests/test_send_update_ping.py
@@ -2,7 +2,7 @@ import unittest.mock
 
 import pytest
 
-from accounts.tests.factories import UserFactory
+from accounts.tests.factories import UserFactory, GroupFactory
 from .. import discourse_sso
 from ..utils import send_update_ping
 
@@ -64,4 +64,77 @@ def test_send_update_ping(settings):
             'admin': False,
             'add_groups': 'aardvark,banana,carrot',
             'remove_groups': 'gingerbread,horseradish,indigo',
+        })
+
+
+@pytest.mark.django_db
+def test_send_update_ping_better(settings):
+    with unittest.mock.patch.object(discourse_sso, 'DiscourseSigner') as \
+            fake_discourse_signer_cls:
+        fake_send_post = unittest.mock.MagicMock()
+        fake_discourse_signer = fake_discourse_signer_cls.return_value
+        fake_discourse_signer.sign.return_value = (
+            'payload', 'signature')
+
+        excluded_group = GroupFactory.create(
+            internal_only=False, internal_name='1-excluded')
+        in_group = GroupFactory.create(
+            internal_only=False, internal_name='2-in')
+        not_in_group = GroupFactory.create(
+            internal_only=False, internal_name='3-not-in')
+        in_internal_group = GroupFactory.create(
+            internal_only=True, internal_name='4-internal-in')
+        not_in_internal_group = GroupFactory.create(
+            internal_only=True, internal_name='5-internal-not-in')
+
+        user = UserFactory.create(
+            email='foo@example.com',
+            username='foo_',
+            mc_username='meep',
+            gh_username='meeep',
+            irc_nick='XxXmeepXxX')
+        user.groups.set([excluded_group, in_group, in_internal_group])
+
+        settings.SSO_ENDPOINTS = TEST_SSO_ENDPOINTS
+        send_update_ping(user, send_post=fake_send_post,
+                         exclude_groups=[excluded_group.id])
+
+        fake_send_post.assert_called_once_with(
+            'http://discourse.example.com/admin/users/sync_sso',
+            data={
+                'sso': 'payload',
+                'sig': 'signature',
+                'api_key': 'discourse-api-key',
+                'api_username': 'system'})
+        fake_discourse_signer.sign.assert_called_once_with({
+            'nonce': str(user.id),
+            'email': 'foo@example.com',
+            'require_activation': 'false',
+            'external_id': user.id,
+            'username': 'foo_',
+            'name': 'foo_',
+            'custom.user_field_1': 'meep',
+            'custom.user_field_2': 'XxXmeepXxX',
+            'custom.user_field_3': 'meeep',
+            'moderator': False,
+            'admin': False,
+            'add_groups': '2-in',
+            'remove_groups': '1-excluded,3-not-in',
+        })
+
+        send_update_ping(user, send_post=fake_send_post)
+        fake_discourse_signer.sign.assert_called_with({
+            'nonce': str(user.id),
+            'email': 'foo@example.com',
+            'require_activation': 'false',
+            'external_id': user.id,
+            'username': 'foo_',
+            'name': 'foo_',
+            'custom.user_field_1': 'meep',
+            'custom.user_field_2': 'XxXmeepXxX',
+            'custom.user_field_3': 'meeep',
+            'moderator': False,
+            'admin': False,
+            'add_groups': '1-excluded,2-in',
+            'remove_groups': '3-not-in',
         })

--- a/spongeauth/sso/tests/test_send_update_ping.py
+++ b/spongeauth/sso/tests/test_send_update_ping.py
@@ -86,6 +86,7 @@ def test_send_update_ping_better(settings):
             internal_only=True, internal_name='4-internal-in')
         not_in_internal_group = GroupFactory.create(
             internal_only=True, internal_name='5-internal-not-in')
+        del not_in_group, not_in_internal_group  # not used; names for documentation
 
         user = UserFactory.create(
             email='foo@example.com',


### PR DESCRIPTION
* Disable username validation if the username hasn't changed
* Replace the full list of users in the group page with an autocompleting thingy
* Sync users if their group membership changes (either forwards, or backwards) - which will sync users if they're edited from the Group admin page, for instance.