### PR TITLE
Allow viewing avatars without a verified email

### DIFF
--- a/spongeauth/accounts/views.py
+++ b/spongeauth/accounts/views.py
@@ -726,6 +726,7 @@ def _read_filefield_to_pil(filefield):
     return Image.open(fh)
 
 
+@middleware.allow_without_verified_email
 def avatar_for_user(request, username):
     user = get_object_or_404(models.User, username=username)
     avatar = user.avatar


### PR DESCRIPTION
Avatars are available when not logged in so there's no value in locking them behind having accepted the ToS or verifying their email address, because it just makes the user experience worse everywhere else.