### PR TITLE
Update a bunch of dependencies.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ Pillow==5.3.0
 oauth2client==4.1.3
 django-crispy-forms==1.7.2
 django-model-utils==3.1.2
-qrcode==6.0
+qrcode==6.1
 pytz==2018.7
 requests==2.21.0
 psycopg2-binary==2.7.6.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django==2.1.5
 django-user-sessions==1.6.0
-Pillow==5.3.0
+Pillow==5.4.1
 oauth2client==4.1.3
 django-crispy-forms==1.7.2
 django-model-utils==3.1.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ oauth2client==4.1.3
 django-crispy-forms==1.7.2
 django-model-utils==3.1.2
 qrcode==6.0
-pytz==2018.7
+pytz==2018.9
 requests==2.21.0
 psycopg2-binary==2.7.6.1
 django-autocomplete-light==3.3.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.1.5
+Django==2.1.7
 django-user-sessions==1.6.0
 Pillow==5.3.0
 oauth2client==4.1.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,5 +7,5 @@ django-model-utils==3.1.2
 qrcode==6.0
 pytz==2018.7
 requests==2.21.0
-psycopg2-binary==2.7.6.1
+psycopg2-binary==2.7.7
 django-autocomplete-light==3.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,6 @@
 pytest-django==3.4.4
 prospector==1.1.6.2
 factory_boy==2.11.1
-Faker==1.0.1
+Faker==1.0.2
 django-debug-toolbar==1.11
 pylint==2.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-pytest-django==3.4.7
+pytest-django==3.4.8
 prospector==1.1.6.2
 factory_boy==2.11.1
 Faker==1.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,4 +5,4 @@ prospector==1.1.6.2
 factory_boy==2.11.1
 Faker==1.0.1
 django-debug-toolbar==1.11
-pylint==2.2.2
+pylint==2.3.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-sentry-sdk==0.6.6
+sentry-sdk==0.7.4
 gunicorn==19.9.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 -r dev.txt
 
-coveralls==1.5.1
+coveralls==1.6.0
 pytest-cov==2.6.1


### PR DESCRIPTION
* Update pylint from 2.2.2 to 2.3.1
* Update sentry-sdk from 0.6.6 to 0.7.4
* Update pytest-django from 3.4.7 to 3.4.8
* Update coveralls from 1.5.1 to 1.6.0
* Update django from 2.1.5 to 2.1.7
* Update faker from 1.0.1 to 1.0.2
* Update psycopg2-binary from 2.7.6.1 to 2.7.7
* Update qrcode from 6.0 to 6.1
* Update pytz from 2018.7 to 2018.9
* Update pillow from 5.3.0 to 5.4.1