### PR TITLE
Set up asynchronous pingbacks for SSO provideers.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ pytz==2019.2
 requests==2.22.0
 psycopg2-binary==2.8.3
 django-autocomplete-light==3.4.1
+django-rq==2.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,4 @@ django-debug-toolbar==2.0
 pylint==2.3.1
 black==19.3b0
 pre-commit==1.18.3
+fakeredis==1.0.5

--- a/spongeauth/spongeauth/settings/base.py
+++ b/spongeauth/spongeauth/settings/base.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     "user_sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_rq",
 ]
 
 MIDDLEWARE = [
@@ -149,3 +150,6 @@ IS_TESTING = False
 ACCOUNTS_AVATAR_CHANGE_MAX_AGE = 1800
 ACCOUNTS_AVATAR_RESIZE_MAX_DIMENSION = 240
 ACCOUNTS_AVATAR_CHANGE_GROUPS = ["dummy"]
+
+# Redis queue settings.
+RQ_QUEUES = {"default": {"HOST": "localhost", "PORT": 6379, "DB": 0, "DEFAULT_TIMEOUT": 300}}

--- a/spongeauth/spongeauth/settings/dev.py
+++ b/spongeauth/spongeauth/settings/dev.py
@@ -11,6 +11,13 @@ MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
 
 INSTALLED_APPS = INSTALLED_APPS + ["debug_toolbar"]
 
+for queue in RQ_QUEUES.values():
+    queue["ASYNC"] = False
+from fakeredis import FakeRedis, FakeStrictRedis
+import django_rq.queues
+
+django_rq.queues.get_redis_connection = lambda _, strict: FakeStrictRedis() if strict else FakeRedis()
+
 
 if not os.environ.get("DJANGO_SETTINGS_SKIP_LOCAL", False):
     try:

--- a/spongeauth/spongeauth/settings/test.py
+++ b/spongeauth/spongeauth/settings/test.py
@@ -4,6 +4,13 @@ from .base import *
 
 IS_TESTING = True
 
+for queue in RQ_QUEUES.values():
+    queue["ASYNC"] = False
+from fakeredis import FakeRedis, FakeStrictRedis
+import django_rq.queues
+
+django_rq.queues.get_redis_connection = lambda _, strict: FakeStrictRedis() if strict else FakeRedis()
+
 if not os.environ.get("DJANGO_SETTINGS_SKIP_LOCAL", False):
     try:
         from .local_settings import *

--- a/spongeauth/spongeauth/urls.py
+++ b/spongeauth/spongeauth/urls.py
@@ -14,9 +14,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import url, include
+from django.conf.urls import url
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.urls import include, path
+
+import django_rq.urls
 
 import accounts.urls
 import api.urls
@@ -38,6 +41,7 @@ urlpatterns = [
     url(r"^sso/", include(sso.urls, "sso")),
     url(r"^$", index, name="index"),
     url(r"^api/", include(api.urls, "api")),
+    path("django-rq/", include(django_rq.urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:

--- a/spongeauth/sso/utils.py
+++ b/spongeauth/sso/utils.py
@@ -1,9 +1,10 @@
 from django.conf import settings
 from django.db.models import Q
 
+import django_rq
 import requests
 
-from accounts.models import Group
+from accounts.models import Group, User
 from . import discourse_sso
 
 
@@ -11,10 +12,9 @@ def _cast_bool(b):
     return str(bool(b)).lower()
 
 
-def make_payload(user, nonce, group=None, exclude_groups=None):
-    group = group or Group
+def make_payload(user, nonce, exclude_groups=None):
     exclude_groups = set(exclude_groups or [])
-    relevant_groups = group.objects.filter(internal_only=False).order_by("internal_name")
+    relevant_groups = Group.objects.filter(internal_only=False).order_by("internal_name")
     filter_q = Q(user=user) & ~Q(pk__in=exclude_groups)
     add_groups = relevant_groups.filter(filter_q).values_list("internal_name", flat=True)
     remove_groups = relevant_groups.exclude(filter_q).values_list("internal_name", flat=True)
@@ -37,29 +37,29 @@ def make_payload(user, nonce, group=None, exclude_groups=None):
     return payload
 
 
-def send_update_ping(user, send_post=None, group=None, exclude_groups=None):
-    send_post = send_post or requests.post
+@django_rq.job
+def send_update_ping_to_endpoint(user_id, endpoint_name, exclude_groups):
+    endpoint_settings = settings.SSO_ENDPOINTS.get(endpoint_name)
+    if not endpoint_settings:
+        return
+    if "sync_sso_endpoint" not in endpoint_settings:
+        return
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return
+    payload = make_payload(user, str(user.pk), exclude_groups=exclude_groups)
+    sso = discourse_sso.DiscourseSigner(endpoint_settings["sso_secret"])
+    out_payload, out_signature = sso.sign(payload)
+    data = {"sso": out_payload, "sig": out_signature, "api_username": "system", "api_key": endpoint_settings["api_key"]}
+    resp = requests.post(endpoint_settings["sync_sso_endpoint"], data=data)
+    resp.raise_for_status()
+
+
+def send_update_ping(user, exclude_groups=None):
     exclude_groups = exclude_groups or []
 
-    payload = make_payload(user, str(user.pk), group=group, exclude_groups=exclude_groups)
-
-    resps = []
-    for endpoint_settings in settings.SSO_ENDPOINTS.values():
+    for endpoint_name, endpoint_settings in settings.SSO_ENDPOINTS.items():
         if "sync_sso_endpoint" not in endpoint_settings:
             continue
-        # TODO(lukegb): make this asynchronous
-        sso = discourse_sso.DiscourseSigner(endpoint_settings["sso_secret"])
-        out_payload, out_signature = sso.sign(payload)
-        data = {
-            "sso": out_payload,
-            "sig": out_signature,
-            "api_username": "system",
-            "api_key": endpoint_settings["api_key"],
-        }
-        resp = send_post(endpoint_settings["sync_sso_endpoint"], data=data)
-        resps.append(resp)
-
-    # TODO(lukegb): reenable this once this is a background task.
-    # for resp in resps:
-    #     pass
-    #     resp.raise_for_status()
+        send_update_ping_to_endpoint.delay(user.pk, endpoint_name, exclude_groups)


### PR DESCRIPTION
This avoids having the pingbacks inline, which means any issues
encountered won't block login nor will they fail pinging the other
service. In addition, retries can be done independently and out of band.

Note that the pingback arguments are deliberately set to just the name
of the service to ping as well as the user ID: this is because we don't
want to accidentally save a "bad" pingback that will overwrite a
later set of data. By storing just the information needed to fetch the
rest of the data, we avoid this issue since we'll always use the
freshest data as at request time.