### PR TITLE
Added django session middleware to fix startup

### DIFF
--- a/spongeauth/spongeauth/settings/base.py
+++ b/spongeauth/spongeauth/settings/base.py
@@ -55,6 +55,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "accounts.middleware.EnforceVerifiedEmails",


### PR DESCRIPTION
PR fixes startup error on newer django versions:
```
?: (admin.E410) 'django.contrib.sessions.middleware.SessionMiddleware' must be in MIDDLEWARE in order to use the admin application.
```