### PR TITLE
chore(mergify): replace strict with queue since strict has been turned down

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "status-success=test (3.x, 12, py3-cov)"
+      - "status-success=test (3.x, 12, lint)"
+
 pull_request_rules:
   - name: Dependency updater - automatic merge on CI passing
     conditions:
@@ -8,7 +14,7 @@ pull_request_rules:
     actions:
       merge:
         method: rebase
-        strict: smart
+        queue: default
       delete_head_branch: {}
   - name: Dependency updater - flag for human review on coverage failing
     conditions:
@@ -39,5 +45,5 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: smart
+        queue: default
       delete_head_branch: {}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,9 +12,9 @@ pull_request_rules:
       - "status-success=test (3.x, 12, py3-cov)"
       - "status-success=test (3.x, 12, lint)"
     actions:
-      merge:
+      queue:
         method: rebase
-        queue: default
+        name: default
       delete_head_branch: {}
   - name: Dependency updater - flag for human review on coverage failing
     conditions:
@@ -43,7 +43,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "label=ready to merge"
     actions:
-      merge:
+      queue:
         method: merge
-        queue: default
+        name: default
       delete_head_branch: {}


### PR DESCRIPTION
`strict` is deprecated and has been turned down: https://blog.mergify.com/strict-mode-deprecation/